### PR TITLE
Adjust hero section and align colors

### DIFF
--- a/Oficina-turismo/Oficina-turismo/Oficina-turismo/assets/css/front/index-satyle.css
+++ b/Oficina-turismo/Oficina-turismo/Oficina-turismo/assets/css/front/index-satyle.css
@@ -159,6 +159,13 @@ footer {
   max-width: auto;
   min-height: 4em;
   max-height: 4em;
+  background-image: linear-gradient(90deg, #080C94, #950808);
+  color: #fff;
+  border: none;
+}
+
+.botones-cuerpo:hover {
+  opacity: 0.9;
 }
 
 .mapa {

--- a/Oficina-turismo/Oficina-turismo/Oficina-turismo/includes/header.php
+++ b/Oficina-turismo/Oficina-turismo/Oficina-turismo/includes/header.php
@@ -12,5 +12,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=Bungee&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="/Oficina-turismo/assets/css/styles.css">
     <link rel="stylesheet" href="/Oficina-turismo/assets/css/front/index-satyle.css">
+    <?php if (!empty($pageStyles) && is_array($pageStyles)): ?>
+        <?php foreach ($pageStyles as $style): ?>
+            <link rel="stylesheet" href="<?= $style ?>">
+        <?php endforeach; ?>
+    <?php endif; ?>
 </head>
 <body>

--- a/Oficina-turismo/Oficina-turismo/Oficina-turismo/includes/navbar.php
+++ b/Oficina-turismo/Oficina-turismo/Oficina-turismo/includes/navbar.php
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+<nav class="navbar navbar-expand-lg navbar-dark nav-color shadow-sm">
     <div class="container-fluid">
         <a class="navbar-brand" href="/Oficina-turismo/index.php">
             <img src="/Oficina-turismo/assets/images/santiago-logo.png" alt="Logo" id="navLogo" class="img-fluid" style="height:40px;">

--- a/Oficina-turismo/Oficina-turismo/Oficina-turismo/index.php
+++ b/Oficina-turismo/Oficina-turismo/Oficina-turismo/index.php
@@ -11,14 +11,22 @@ include('includes/navbar.php');
 ?>
 
 <main class="container py-4">
-    <section class="text-center py-5 hero bg-light rounded">
-        <h1 class="display-4 mb-3"><?= $texto['bienvenida'] ?></h1>
-        <p class="lead mb-4"><?= $texto['mision'] ?></p>
-        <a href="pages/destinos.php" class="btn btn-primary"><?= $texto['btn_explorar'] ?></a>
+    <section class="text-center py-5 hero rounded shadow-sm">
+        <h1 class="display-4 mb-3 bungee-regular">
+            <?= $texto['bienvenida'] ?>
+        </h1>
+        <p class="lead mb-4 bebas-neue-regular">
+            <?= $texto['mision'] ?>
+        </p>
+        <a href="pages/destinos.php" class="btn btn-primary botones-cuerpo">
+            <?= $texto['btn_explorar'] ?>
+        </a>
     </section>
 
     <section class="intro text-center mt-5">
-        <h2><?= $texto['titulo'] ?></h2>
+        <h2 class="bebas-neue-regular">
+            <?= $texto['titulo'] ?>
+        </h2>
     </section>
     <div class="text-center mt-3">
         <a href="?lang=es" class="me-2">🇦🇷 Español</a> | <a href="?lang=en" class="ms-2">🇬🇧 English</a>

--- a/Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/destinos.php
+++ b/Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/destinos.php
@@ -1,6 +1,7 @@
 <?php 
 session_start();
 require_once(__DIR__ . '/../config/db.php');
+$pageStyles = ['/Oficina-turismo/assets/css/front/destinos-style.css'];
 include(__DIR__ . '/../includes/header.php');
 include(__DIR__ . '/../includes/navbar.php');
 
@@ -55,15 +56,19 @@ try {
             }
 
             while ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                echo "<div class='card'>";
-                echo "<img src='/Oficina-turismo/assets/images/{$row['ImagenDelLugar']}' alt='{$row['Nombre']}' width='300'>";
-                echo "<h3>{$row['Nombre']}</h3>";
-                echo "<p><strong>Categoría:</strong> {$row['CategoriaNombre']}</p>";
-                echo "<p><strong>Ubicación:</strong> {$row['Ubicacion']}</p>";
-                echo "<p><strong>Horario:</strong> {$row['Horario']}</p>";
-                echo "<p><strong>Costo:</strong> \$" . number_format($row['CostoDeVisita'], 2) . "</p>";
-                echo "<p><strong>Edad Recomendada:</strong> {$row['EdadRecomendada']}+</p>";
-                echo "<p><a href='/Oficina-turismo/pages/detalle_destino.php?id={$row['IdLugar']}' class='btn'>Ver más</a></p>";
+                echo "<div class='col'>";
+                echo "  <div class='card tarjeta-destinos h-100 text-center shadow-sm'>";
+                echo "    <img class='card-img-top tarjeta-imagen' src='/Oficina-turismo/assets/images/{$row['ImagenDelLugar']}' alt='{$row['Nombre']}'>";
+                echo "    <div class='card-body'>";
+                echo "        <h3 class='card-title h5 bebas-neue-regular mb-2'>{$row['Nombre']}</h3>";
+                echo "        <p class='card-text'><strong>Categoría:</strong> {$row['CategoriaNombre']}</p>";
+                echo "        <p class='card-text'><strong>Ubicación:</strong> {$row['Ubicacion']}</p>";
+                echo "        <p class='card-text'><strong>Horario:</strong> {$row['Horario']}</p>";
+                echo "        <p class='card-text'><strong>Costo:</strong> \$" . number_format($row['CostoDeVisita'], 2) . "</p>";
+                echo "        <p class='card-text'><strong>Edad Recomendada:</strong> {$row['EdadRecomendada']}+</p>";
+                echo "        <a href='/Oficina-turismo/pages/detalle_destino.php?id={$row['IdLugar']}' class='btn btn-primary botones-cuerpo'>Ver más</a>";
+                echo "    </div>";
+                echo "  </div>";
                 echo "</div>";
             }
 

--- a/Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/detalle_destino.php
+++ b/Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/detalle_destino.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require_once(__DIR__ . '/../config/db.php');
+$pageStyles = ['/Oficina-turismo/assets/css/front/destino-style.css'];
 include(__DIR__ . '/../includes/header.php');
 include(__DIR__ . '/../includes/navbar.php');
 

--- a/Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/detalle_ruta.php
+++ b/Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/detalle_ruta.php
@@ -4,6 +4,7 @@ error_reporting(E_ALL);
 
 session_start();
 require_once(__DIR__ . '/../config/db.php');
+$pageStyles = ['/Oficina-turismo/assets/css/front/recorrido-style.css'];
 include(__DIR__ . '/../includes/header.php');
 include(__DIR__ . '/../includes/navbar.php');
 
@@ -56,13 +57,17 @@ foreach ($destinos as $d) {
     <h3 class="mt-4">Destinos incluidos en esta ruta</h3>
     <div class="grid row row-cols-1 row-cols-md-3 g-4">
         <?php foreach ($destinos as $d): ?>
-            <div class="card">
-                <img src="/Oficina-turismo/assets/images/<?= $d['ImagenDelLugar'] ?>" alt="<?= $d['Nombre'] ?>" width="300">
-                <h4><?= $d['Nombre'] ?></h4>
-                <p><strong>Ubicación:</strong> <?= $d['Ubicacion'] ?></p>
-                <p><strong>Horario:</strong> <?= $d['Horario'] ?></p>
-                <p><strong>Costo:</strong> $<?= number_format($d['CostoDeVisita'], 2) ?></p>
-                <p><?= $d['descripcion'] ?? 'Descripción no disponible.' ?></p>
+            <div class="col">
+                <div class="card tarjeta-recorridos h-100 text-center shadow-sm">
+                    <img src="/Oficina-turismo/assets/images/<?= $d['ImagenDelLugar'] ?>" alt="<?= $d['Nombre'] ?>" class="card-img-top tarjeta-imagen">
+                    <div class="card-body">
+                        <h4 class="card-title h6 bebas-neue-regular mb-2"><?= $d['Nombre'] ?></h4>
+                        <p class="card-text"><strong>Ubicación:</strong> <?= $d['Ubicacion'] ?></p>
+                        <p class="card-text"><strong>Horario:</strong> <?= $d['Horario'] ?></p>
+                        <p class="card-text"><strong>Costo:</strong> $<?= number_format($d['CostoDeVisita'], 2) ?></p>
+                        <p class="card-text"><?= $d['descripcion'] ?? 'Descripción no disponible.' ?></p>
+                    </div>
+                </div>
             </div>
         <?php endforeach; ?>
     </div>

--- a/Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/planificador.php
+++ b/Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/planificador.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require_once(__DIR__ . '/../config/db.php');
+$pageStyles = ['/Oficina-turismo/assets/css/planficador.css'];
 include(__DIR__ . '/../includes/header.php');
 include(__DIR__ . '/../includes/navbar.php');
 
@@ -9,8 +10,7 @@ $stmt = $pdo->query("SELECT * FROM destinos WHERE Latitud IS NOT NULL AND Longit
 $destinos = $stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
-<!-- ✅ Estilo del planificador -->
-<link rel="stylesheet" href="/Oficina-turismo/assets/css/planificador.css">
+
 
 <main class="container py-4" style="max-width: 1100px;">
     <h2 class="mb-4 text-center">🧭 Planificador de Ruta Personalizada</h2>

--- a/Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/rutas.php
+++ b/Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/rutas.php
@@ -1,6 +1,7 @@
 <?php 
 session_start();
 require_once(__DIR__ . '/../config/db.php');
+$pageStyles = ['/Oficina-turismo/assets/css/front/recorridos-style.css'];
 include(__DIR__ . '/../includes/header.php');
 include(__DIR__ . '/../includes/navbar.php');
 ?>
@@ -12,16 +13,17 @@ include(__DIR__ . '/../includes/navbar.php');
         try {
             $stmt = $pdo->query("SELECT * FROM rutas");
             while ($ruta = $stmt->fetch(PDO::FETCH_ASSOC)) {
-                echo "<div class='card'>";
-                echo "<h3>{$ruta['Nombre']}</h3>";
-                echo "<p><strong>Duración:</strong> {$ruta['Duracion']} min</p>";
-                echo "<p><strong>Costo:</strong> \$" . number_format($ruta['CostoDelRecorrido'], 2) . "</p>";
-                echo "<p><strong>Edad Recomendada:</strong> {$ruta['EdadRecomendada']}+</p>";
-                echo "<p>{$ruta['Descripcion']}</p>";
-
-                // 🔗 Enlace al detalle de la ruta
-                echo "<p><a href='/Oficina-turismo/pages/detalle_ruta.php?id={$ruta['IdRecorrido']}' class='btn'>Ver más</a></p>";
-
+                echo "<div class='col'>";
+                echo "  <div class='card tarjeta-recorrido h-100 text-center shadow-sm'>";
+                echo "    <div class='card-body'>";
+                echo "      <h3 class='card-title h5 bebas-neue-regular mb-2'>{$ruta['Nombre']}</h3>";
+                echo "      <p class='card-text'><strong>Duración:</strong> {$ruta['Duracion']} min</p>";
+                echo "      <p class='card-text'><strong>Costo:</strong> \$" . number_format($ruta['CostoDelRecorrido'], 2) . "</p>";
+                echo "      <p class='card-text'><strong>Edad Recomendada:</strong> {$ruta['EdadRecomendada']}+</p>";
+                echo "      <p class='card-text'>{$ruta['Descripcion']}</p>";
+                echo "      <a href='/Oficina-turismo/pages/detalle_ruta.php?id={$ruta['IdRecorrido']}' class='btn btn-primary botones-cuerpo'>Ver más</a>";
+                echo "    </div>";
+                echo "  </div>";
                 echo "</div>";
             }
         } catch (PDOException $e) {

--- a/css/index-satyle.css
+++ b/css/index-satyle.css
@@ -159,6 +159,13 @@ footer {
   max-width: auto;
   min-height: 4em;
   max-height: 4em;
+  background-image: linear-gradient(90deg, #080C94, #950808);
+  color: #fff;
+  border: none;
+}
+
+.botones-cuerpo:hover {
+  opacity: 0.9;
 }
 
 .mapa {


### PR DESCRIPTION
## Summary
- remove background color override from hero section
- revert navbar gradient to match existing styles
- link page-level stylesheets and refactor destination & route cards

## Testing
- `php -l Oficina-turismo/Oficina-turismo/Oficina-turismo/index.php` *(fails: command not found)*
- `php -l Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/destinos.php` *(fails: command not found)*
- `php -l Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/detalle_destino.php` *(fails: command not found)*
- `php -l Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/rutas.php` *(fails: command not found)*
- `php -l Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/detalle_ruta.php` *(fails: command not found)*
- `php -l Oficina-turismo/Oficina-turismo/Oficina-turismo/pages/planificador.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_684fe8775ce48332ad6b0fc9e653513a